### PR TITLE
Update `substrate.io` links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Playground templates can be [created and maintained](https://paritytech.github.i
 
 ### Web
 
-Access playground at [playground.substrate.dev](https://playground.substrate.dev).
+Access playground at [docs.substrate.io/playground/](https://docs.substrate.io/playground/).
 
 ### CLI
 


### PR DESCRIPTION
https://docs.substrate.io/playground/ is the new home :rocket: 
There are many `substrate.dev` files _not_ touched throughout this repo - @jeluard I think you know best what should be changed for these? Like sating links etc.