### PR TITLE
Pin GHA version to hash

### DIFF
--- a/.github/workflows/ci-playground.yml
+++ b/.github/workflows/ci-playground.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Show images
         run: docker images
 
-      - uses: AbsaOSS/k3d-action@v2
+      - uses: AbsaOSS/k3d-action@b176c2a6dcae72e3e64e3e4d61751904ec314002 # v2.3.0
         with:
           cluster-name: "pg-cluster"
           args: >-


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.

Related issues and policy:
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies