### PR TITLE
fix gha set-output command

### DIFF
--- a/.github/workflows/ci-playground.yml
+++ b/.github/workflows/ci-playground.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set environment
         id: env
         run: |
-          echo ::set-output name=sha::sha-${GITHUB_SHA::7}
+          echo "sha=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: Set up Kustomize
         run: |-


### PR DESCRIPTION
GitHub is going to deprecate `save-state` and `set-output` commands. [More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR adjusts GHA workflow to use new syntax.

Part of https://github.com/paritytech/ci_cd/issues/805